### PR TITLE
[chore]CSS を TailWind CSS に置き換える

### DIFF
--- a/src/pages/bubbles.tsx
+++ b/src/pages/bubbles.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import React, { useEffect, useState } from 'react';
-import tw, { css } from 'twin.macro';
+import 'twin.macro';
 import {
   CartesianGrid,
   Cell,
@@ -62,23 +62,6 @@ const CustomizedTooltip = (props: TooltipProps<ValueType, NameType>) => {
   );
 };
 
-const container = css`
-  height: 98%;
-  display: flex;
-  flex-direction: column;
-  ${tw`m-4 p-4 rounded bg-gray-600`}
-`;
-
-const headerContainer = css`
-  height: 15em;
-  width: 100%;
-`;
-
-const innerContainer = css`
-  height: 100%;
-  width: 100%;
-`;
-
 const Bubbles = () => {
   const [year, setYear] = useState(years[0]);
   const [auto, setAuto] = useState(true);
@@ -104,8 +87,8 @@ const Bubbles = () => {
       <Head>
         <title>貧困可視化プロトタイプ：スターチャート</title>
       </Head>
-      <div css={container}>
-        <div css={headerContainer}>
+      <div tw="h-full flex flex-col m-4 p-4 rounded bg-gray-600">
+        <div tw="h-64 w-full">
           <h1 tw='text-5xl text-white font-bold'>
             貧困可視化プロトタイプ：スターチャート
           </h1>
@@ -142,7 +125,7 @@ const Bubbles = () => {
             tw='w-full h-5'
           />
         </div>
-        <div css={innerContainer}>
+        <div tw="h-full w-full">
           <ResponsiveContainer>
             <ScatterChart
               margin={{

--- a/src/pages/network.tsx
+++ b/src/pages/network.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import React from 'react';
-import tw, { css } from 'twin.macro';
+import 'twin.macro';
 
 import Graph from 'react-graph-vis';
 

--- a/src/pages/network.tsx
+++ b/src/pages/network.tsx
@@ -37,36 +37,19 @@ const NetworkDiagram = () => {
   return <Graph graph={graph} />;
 };
 
-const container = css`
-  height: 98%;
-  display: flex;
-  flex-direction: column;
-  ${tw`m-4 p-4 rounded bg-gray-600`}
-`;
-
-const headerContainer = css`
-  height: 15em;
-  width: 100%;
-`;
-
-const innerContainer = css`
-  height: 100%;
-  width: 100%;
-`;
-
 const Network = () => {
   return (
     <>
       <Head>
         <title>貧困可視化プロトタイプ：ネットワーク</title>
       </Head>
-      <div css={container}>
-        <div css={headerContainer}>
+      <div tw="h-full flex flex-col m-4 p-4 rounded bg-gray-600">
+        <div tw="h-64 w-full">
           <h1 tw='text-5xl text-white font-bold'>
             貧困可視化プロトタイプ：ネットワーク
           </h1>
         </div>
-        <div css={innerContainer}>
+        <div tw="h-full w-full">
           <NetworkDiagram />
         </div>
       </div>

--- a/src/pages/recharts.tsx
+++ b/src/pages/recharts.tsx
@@ -13,16 +13,12 @@ import {
 
 import data from '../data/test.json';
 
-const container = css`
-  ${tw`mx-auto m-4 p-4 rounded bg-gray-600`}
-`;
-
 const Recharts = () => (
   <>
     <Head>
       <title>貧困可視化プロトタイプ：Recharts</title>
     </Head>
-    <div css={container}>
+    <div tw="mx-auto m-4 p-4 rounded bg-gray-600">
       <main>
         <h1 tw='text-5xl text-white font-bold'>貧困可視化：Recharts</h1>
         <h2 tw='text-3xl text-white'>

--- a/src/pages/words.tsx
+++ b/src/pages/words.tsx
@@ -1,20 +1,29 @@
 import Head from 'next/head';
 import React from 'react';
-import tw, { css } from 'twin.macro';
+import 'twin.macro';
 import { TagCloud } from 'react-tagcloud';
 
 import data from '../data/voice_single_mother_2020_08_words.json';
 
-const container = css`
-  ${tw`mx-auto m-4 p-4 rounded bg-gray-600`}
-`;
+export async function getStaticProps() {
+  // fetch list of posts
+  const response = await fetch(
+    'https://jsonplaceholder.typicode.com/posts?_page=1'
+  )
+  const postList = await response.json()
+  return {
+    props: {
+      postList,
+    },
+  }
+}
 
 const Words = () => (
   <>
     <Head>
       <title>貧困可視化プロトタイプ：ワードクラウド</title>
     </Head>
-    <div css={container}>
+    <div tw="mx-auto m-4 p-4 rounded bg-gray-600">
       <h1 tw='text-5xl text-white font-bold'>貧困可視化：ワードクラウド</h1>
       <h2 tw='text-3xl text-white'>
         <a href='https://note.com/single_mama_pj/n/n83bb1e08b706'>
@@ -29,3 +38,4 @@ const Words = () => (
 );
 
 export default Words;
+


### PR DESCRIPTION
## 概要

本筋からズレるんですが、CSS と TailWind CSS を混ぜて書くことで自分の環境だとコードハイライトが壊れてました。
CSS で書けるものは TailWInd CSS で大体かけるので、後者に統一させようとしています。
`height: 98%` で余白を合わせてるところは再現難しいので高さが変わってますが、 _app.tsx か _document.tsx で適切にスタイルをおけば解決すると思っています。