### PR TITLE
mongoDBをlocalでも動くようにする

### DIFF
--- a/src/utils/dbConnect.ts
+++ b/src/utils/dbConnect.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 
-const MONGODB_URI = process.env.MONGODB_URI;
+const MONGODB_URI = process.env.MONGODB_URI ?? 'mongodb://localhost:27017';
 
 if (!MONGODB_URI) {
   throw new Error(


### PR DESCRIPTION
今のところ必要なさそうですがいつか必要になりそうなのでやっておきます
localでmongoを動かしていれば動きます
localで`curl "localhost:3000/api/people"`して動いてることを確認しました